### PR TITLE
Restore a couple of data types

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -70,8 +70,13 @@ const getMssqlType = function (type, length) {
     case tds.TYPES.SmallMoney: return TYPES.SmallMoney
     case tds.TYPES.Numeric: return TYPES.Numeric
     case tds.TYPES.Decimal: return TYPES.Decimal
+    case tds.TYPES.Time: return TYPES.Time
+    case tds.TYPES.Date: return TYPES.Date
     case tds.TYPES.DateTime: return TYPES.DateTime
+    case tds.TYPES.DateTime2: return TYPES.DateTime2
+    case tds.TYPES.DateTimeOffset: return TYPES.DateTimeOffset
     case tds.TYPES.SmallDateTime: return TYPES.SmallDateTime
+    case tds.TYPES.UniqueIdentifier: return TYPES.UniqueIdentifier
     case tds.TYPES.Image: return TYPES.Image
     case tds.TYPES.Binary: return TYPES.Binary
     case tds.TYPES.VarBinary: return TYPES.VarBinary


### PR DESCRIPTION
These datatypes are still entirely supported and especially types such as `DateTime2` are important to have in the library as [the old DateTime is being deprecated](https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql?view=sql-server-2017). 

At least for DateTime2 I have confirmed this works over many many requests for a private project for my organization where I am using node-mssql.